### PR TITLE
Replace telegram markdown characters

### DIFF
--- a/packages/interactive/telegram_info.yaml
+++ b/packages/interactive/telegram_info.yaml
@@ -61,7 +61,7 @@ automation:
         message: "Locations are showing as -
 
           {% for state in states.device_tracker %}
-            {{- state.name }} - {{ state.state_with_unit }}
+            {{- state.name }} - {{ state.state_with_unit|replace('_','-') }}
 
           {% endfor %}
 


### PR DESCRIPTION
device_tracker state might contain telegram markdown characters (i.e. '_')
In this case sending the message will fail with error:
```
2018-09-08 11:44:12 ERROR (Thread-7) [homeassistant.components.telegram_bot] Error sending message: Can't parse entities: can't find end of the entity starting at byte offset 115.
```